### PR TITLE
Use image from the CMS for Room Cards

### DIFF
--- a/app/scss/base/html.scss
+++ b/app/scss/base/html.scss
@@ -22,7 +22,7 @@ body {
   }
 
 img {
-    max-width: 100%;
+    width: 100%;
     height: auto;
 }
 

--- a/views/partials/roomCard.njk
+++ b/views/partials/roomCard.njk
@@ -1,7 +1,7 @@
 {% macro roomCard(data) %}
 <div class="room-card">
     <div class="room-card__image-container">
-        <img src="/assets/dalston-library-education-room1.jpg" alt="{{ data.title.rendered }}">
+        <img src="{{ data.acf.main_image.sizes.thumbnail }}" alt="{{ data.acf.main_image.caption }}">
     </div>
     <div class="room-card__meta-container">
        <div class="room-meta__room-name lbh-heading-h5">


### PR DESCRIPTION
Inject the ACF main image thubnail from the CMS on the room card, and adjust responsve image width setting.